### PR TITLE
Fix various pedantic compile time warnings from clang.

### DIFF
--- a/include/mtest.h
+++ b/include/mtest.h
@@ -75,7 +75,7 @@ static int test_name(void) {                                                    
 #define RUN_TESTS(...) do {                                                                                             \
     int success = 0, failed = 0;                                                                                        \
     int(*test_functions[])(void) = {__VA_ARGS__};                                                                       \
-    for (int i = 0; i < sizeof(test_functions)/sizeof(int(*)(void)); ++i)                                               \
+    for (int i = 0; i < (int)(sizeof(test_functions)/sizeof(int(*)(void))); ++i)                                        \
         test_functions[i]() ? failed++ : success++;                                                                     \
     printf("Tests run: %d. Succeeded: %d. Failed: %d", success+failed, success, failed);                                \
     if (failed) exit(EXIT_FAILURE);                                                                                     \
@@ -94,7 +94,7 @@ int main (int argc, char *argv[]) {                                             
         char* names = (char *)malloc(strlen(names_static)+1);                                                           \
         strcpy(names, names_static);                                                                                    \
         char* token = strtok(names, " ,");                                                                              \
-        for (int i = 0; token != NULL && i < sizeof(test_functions)/sizeof(int(*)(void)); ++i) {                        \
+        for (int i = 0; token != NULL && i < (int)(sizeof(test_functions)/sizeof(int(*)(void))); ++i) {                 \
             if (list_test_cases) {                                                                                      \
                 printf("%s;", token);                                                                                   \
             } else if (strcmp(argv[1], token) == 0) {                                                                   \

--- a/include/mtest.h
+++ b/include/mtest.h
@@ -63,10 +63,10 @@
 #define REQUIRE_NE_STRING(expected, actual) REQUIRE_(strcmp((expected), (actual)),  "REQUIRE_NE_STRING(%s,%s) failed (\"%s\" == \"%s\")", #expected, #actual, expected, actual)
 
 // A test case is implemented as a function that returns 0 if the test passes and 1 if it fails.
-#define TEST_CASE(test_name, command...)                                                                                \
+#define TEST_CASE(test_name, ...)                                                                                       \
 static int test_name(void) {                                                                                            \
     int _mtest_result_ = 0;                                                                                             \
-    { command }                                                                                                         \
+    { __VA_ARGS__ }                                                                                                     \
     return _mtest_result_;                                                                                              \
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_executable(test_mtest test_mtest.c)
 target_link_libraries(test_mtest mtest)
+# Avoid relying on hidden compiler behavior when compiling test_mtest.
+target_compile_options(test_mtest PRIVATE -Wall -Wextra -Wpedantic)
 
 # Automatically discover test cases in test_mtest and add them to CTest.
 discover_tests(test_mtest)


### PR DESCRIPTION
This PR should fix the various warnings you get from running clang with the compile flags: `-Wall -Wextra -Wpedantic`. :smile: 