### PR TITLE
fix: pedantic warning for named variadic macros

### DIFF
--- a/test/test_mtest.c
+++ b/test/test_mtest.c
@@ -8,8 +8,8 @@
 // For regular usage of "mtest.h", consider macros named `_NE_` and similar
 // to invert the test conditions themselves, rather than resorting to
 // full test case inversion.
-#define TEST_FAILING_CASE(test_name, command...) \
-TEST_CASE(wrapped_##test_name, { command }) \
+#define TEST_FAILING_CASE(test_name, ...) \
+TEST_CASE(wrapped_##test_name, { __VA_ARGS__ }) \
 static int test_name(void) { \
     return wrapped_##test_name() ? 0 : 1; \
 }


### PR DESCRIPTION
A very simple fix PR, not sure how i missed this in the first one. :sweat_smile: 

Fixes the following warning:
```
/mnt/home/sofi/Code/Github/mtest/test/test_mtest.c:11:45: warning: ISO C does not permit named variadic macros [-Wvariadic-macros]
   11 | #define TEST_FAILING_CASE(test_name, command...) \
      |  
```